### PR TITLE
Add standalone browser-based Yamal Bovanenkovo FPS simulation

### DIFF
--- a/yamal-bovanenkovo-sim/README.md
+++ b/yamal-bovanenkovo-sim/README.md
@@ -1,0 +1,35 @@
+# Yamal Bovanenkovo Construction Simulator
+
+Browser-based first-person 3D walking simulation of an arctic industrial construction environment inspired by Yamal / Bovanenkovo.
+
+## Features
+
+- Large map with central construction site, modular camp, pipeline storage and distant tundra.
+- First-person controls (WASD, mouse look, Shift sprint, Space jump) via Pointer Lock.
+- Arctic terrain with procedural height variation and cold lighting.
+- Dynamic environment: day/dusk switch (`T`) and automatic cycle.
+- Snow weather states: light snow, clear visibility, snow mist.
+- Construction equipment made from primitives: bulldozers, dump trucks, crawler crane, pipelayer, ATVs.
+- Industrial details: floodlights, containers, roads, fences, utility clusters.
+- Rare arctic wildlife in distant tundra: foxes and very rare polar bears.
+- HUD with coordinates, controls, weather and zone detection.
+
+## Run
+
+1. Open `index.html` directly in a modern browser (Chrome/Edge/Firefox).
+2. Click `Начать`.
+3. Grant pointer lock by interacting with the page.
+4. Walk through zones:
+   - Camp and HQ (negative X, positive Z)
+   - Construction core (center)
+   - Pipe storage (positive X)
+   - Empty tundra (far radius)
+
+## Controls
+
+- `W A S D` — move
+- `Mouse` — look
+- `Shift` — sprint
+- `Space` — jump
+- `T` — toggle day/dusk mode
+- `Esc` — unlock cursor and show start overlay

--- a/yamal-bovanenkovo-sim/animals.js
+++ b/yamal-bovanenkovo-sim/animals.js
@@ -1,0 +1,108 @@
+window.YamalSim = window.YamalSim || {};
+
+window.YamalSim.animals = (() => {
+  const { rand, randInt } = window.YamalSim.utils;
+
+  function createFox() {
+    const g = new THREE.Group();
+    const mat = new THREE.MeshStandardMaterial({ color: 0xf0f3f6, roughness: 0.95 });
+
+    const body = new THREE.Mesh(new THREE.BoxGeometry(1.2, 0.55, 0.45), mat);
+    body.position.y = 0.45;
+    g.add(body);
+
+    const head = new THREE.Mesh(new THREE.BoxGeometry(0.45, 0.36, 0.34), mat);
+    head.position.set(0.75, 0.6, 0);
+    g.add(head);
+
+    const tail = new THREE.Mesh(new THREE.ConeGeometry(0.16, 0.8, 6), mat);
+    tail.rotation.z = -Math.PI / 2.2;
+    tail.position.set(-0.78, 0.55, 0);
+    g.add(tail);
+
+    return g;
+  }
+
+  function createBear() {
+    const g = new THREE.Group();
+    const mat = new THREE.MeshStandardMaterial({ color: 0xe6ecef, roughness: 0.9 });
+
+    const body = new THREE.Mesh(new THREE.BoxGeometry(3.4, 1.5, 1.3), mat);
+    body.position.y = 1.3;
+    g.add(body);
+
+    const head = new THREE.Mesh(new THREE.BoxGeometry(1.0, 0.8, 0.8), mat);
+    head.position.set(1.95, 1.6, 0);
+    g.add(head);
+
+    const hump = new THREE.Mesh(new THREE.BoxGeometry(1.1, 0.6, 1.0), mat);
+    hump.position.set(0.4, 1.9, 0);
+    g.add(hump);
+
+    return g;
+  }
+
+  function createAnimals(terrain) {
+    const group = new THREE.Group();
+    group.name = "ArcticAnimals";
+    const agents = [];
+
+    const foxCount = 8;
+    for (let i = 0; i < foxCount; i++) {
+      const fox = createFox();
+      const angle = rand(0, Math.PI * 2);
+      const radius = rand(650, 980);
+      const x = Math.cos(angle) * radius;
+      const z = Math.sin(angle) * radius;
+      fox.position.set(x, terrain.getHeightAt(x, z) + 0.02, z);
+      fox.rotation.y = rand(0, Math.PI * 2);
+      fox.scale.setScalar(rand(0.95, 1.15));
+      group.add(fox);
+      agents.push({ mesh: fox, speed: rand(0.6, 1.2), turnTimer: rand(1, 5), type: "fox" });
+    }
+
+    const bearCount = 2;
+    for (let i = 0; i < bearCount; i++) {
+      const bear = createBear();
+      const angle = rand(0, Math.PI * 2);
+      const radius = rand(840, 1100);
+      const x = Math.cos(angle) * radius;
+      const z = Math.sin(angle) * radius;
+      bear.position.set(x, terrain.getHeightAt(x, z) + 0.05, z);
+      bear.rotation.y = rand(0, Math.PI * 2);
+      group.add(bear);
+      agents.push({ mesh: bear, speed: rand(0.28, 0.45), turnTimer: rand(3, 8), type: "bear" });
+    }
+
+    return { group, agents };
+  }
+
+  function updateAnimals(state, terrain, delta) {
+    state.agents.forEach((a) => {
+      a.turnTimer -= delta;
+      if (a.turnTimer <= 0) {
+        a.mesh.rotation.y += rand(-0.8, 0.8);
+        a.turnTimer = a.type === "fox" ? rand(1.5, 4.2) : rand(4.5, 10);
+      }
+
+      if (Math.random() < (a.type === "fox" ? 0.75 : 0.4) * delta) {
+        const dirX = Math.sin(a.mesh.rotation.y);
+        const dirZ = Math.cos(a.mesh.rotation.y);
+        a.mesh.position.x += dirX * a.speed * delta;
+        a.mesh.position.z += dirZ * a.speed * delta;
+
+        const r = Math.hypot(a.mesh.position.x, a.mesh.position.z);
+        if (r < 580 || r > 1200) {
+          a.mesh.rotation.y += Math.PI * (randInt(0, 1) ? 0.85 : -0.85);
+        }
+      }
+
+      a.mesh.position.y = terrain.getHeightAt(a.mesh.position.x, a.mesh.position.z) + (a.type === "fox" ? 0.02 : 0.05);
+    });
+  }
+
+  return {
+    createAnimals,
+    updateAnimals,
+  };
+})();

--- a/yamal-bovanenkovo-sim/buildings.js
+++ b/yamal-bovanenkovo-sim/buildings.js
@@ -1,0 +1,131 @@
+window.YamalSim = window.YamalSim || {};
+
+window.YamalSim.buildings = (() => {
+  const C = {
+    wallLight: 0xcdd8e1,
+    wallBlue: 0x8ea0b2,
+    roofDark: 0x4a5968,
+    trim: 0x6a7a89,
+    window: 0xadc7de,
+  };
+
+  function makeModule({ w = 22, h = 6, d = 10, color = C.wallLight, roof = C.roofDark }) {
+    const g = new THREE.Group();
+    const body = new THREE.Mesh(
+      new THREE.BoxGeometry(w, h, d),
+      new THREE.MeshStandardMaterial({ color, roughness: 0.93, metalness: 0.05 })
+    );
+    body.position.y = h * 0.5;
+    body.castShadow = true;
+    body.receiveShadow = true;
+    g.add(body);
+
+    const roofMesh = new THREE.Mesh(
+      new THREE.BoxGeometry(w + 0.6, 0.6, d + 0.6),
+      new THREE.MeshStandardMaterial({ color: roof, roughness: 0.82 })
+    );
+    roofMesh.position.y = h + 0.28;
+    roofMesh.castShadow = true;
+    g.add(roofMesh);
+
+    const windowMat = new THREE.MeshStandardMaterial({ color: C.window, emissive: 0x2f4c67, emissiveIntensity: 0.18 });
+    const windowGeo = new THREE.BoxGeometry(1.8, 1.2, 0.1);
+    for (let i = -3; i <= 3; i++) {
+      if (i === 0) continue;
+      const wx = (w / 8) * i;
+      const win = new THREE.Mesh(windowGeo, windowMat);
+      win.position.set(wx, h * 0.58, d / 2 + 0.06);
+      g.add(win);
+    }
+
+    const stairs = new THREE.Mesh(
+      new THREE.BoxGeometry(3.3, 0.8, 2.6),
+      new THREE.MeshStandardMaterial({ color: C.trim, roughness: 0.95 })
+    );
+    stairs.position.set(0, 0.4, d / 2 + 1.3);
+    stairs.receiveShadow = true;
+    g.add(stairs);
+
+    return g;
+  }
+
+  function makeFenceLine(length = 120) {
+    const g = new THREE.Group();
+    const postGeo = new THREE.CylinderGeometry(0.12, 0.12, 2.2, 6);
+    const postMat = new THREE.MeshStandardMaterial({ color: 0x69737d, roughness: 0.9 });
+
+    for (let i = 0; i <= length / 6; i++) {
+      const x = -length / 2 + i * 6;
+      const p = new THREE.Mesh(postGeo, postMat);
+      p.position.set(x, 1.1, 0);
+      g.add(p);
+
+      if (i < length / 6) {
+        const rail = new THREE.Mesh(
+          new THREE.BoxGeometry(6, 0.08, 0.08),
+          new THREE.MeshStandardMaterial({ color: 0x7b868f })
+        );
+        rail.position.set(x + 3, 1.5, 0);
+        g.add(rail);
+      }
+    }
+
+    return g;
+  }
+
+  function createCamp(terrain) {
+    const group = new THREE.Group();
+    group.name = "ModularCamp";
+
+    const rows = [
+      { z: 120, count: 5, color: C.wallLight },
+      { z: 150, count: 5, color: C.wallBlue },
+      { z: 182, count: 5, color: C.wallLight },
+    ];
+
+    rows.forEach((row, rIdx) => {
+      for (let i = 0; i < row.count; i++) {
+        const mod = makeModule({ color: row.color, roof: rIdx % 2 ? 0x485764 : 0x556777 });
+        const x = -380 + i * 56;
+        const z = row.z;
+        mod.position.set(x, terrain.getHeightAt(x, z), z);
+        group.add(mod);
+      }
+    });
+
+    const hq = makeModule({ w: 44, h: 7, d: 16, color: 0x9aa9b6, roof: 0x3f4e5f });
+    hq.position.set(-220, terrain.getHeightAt(-220, 78), 78);
+    group.add(hq);
+
+    const checkpoint = makeModule({ w: 14, h: 5, d: 8, color: 0xa5b4c2, roof: 0x4c5c6a });
+    checkpoint.position.set(-430, terrain.getHeightAt(-430, 98), 98);
+    group.add(checkpoint);
+
+    for (let i = 0; i < 16; i++) {
+      const c = new THREE.Mesh(
+        new THREE.BoxGeometry(6, 2.6, 2.6),
+        new THREE.MeshStandardMaterial({ color: i % 2 ? 0x8897a4 : 0x6f7f8d, roughness: 0.9 })
+      );
+      const x = -440 + (i % 8) * 10;
+      const z = 212 + Math.floor(i / 8) * 4;
+      c.position.set(x, terrain.getHeightAt(x, z) + 1.3, z);
+      c.castShadow = true;
+      c.receiveShadow = true;
+      group.add(c);
+    }
+
+    const fenceA = makeFenceLine(280);
+    fenceA.position.set(-250, terrain.getHeightAt(-250, 92), 92);
+    group.add(fenceA);
+
+    const fenceB = makeFenceLine(280);
+    fenceB.position.set(-250, terrain.getHeightAt(-250, 206), 206);
+    group.add(fenceB);
+
+    return group;
+  }
+
+  return {
+    createCamp,
+  };
+})();

--- a/yamal-bovanenkovo-sim/construction.js
+++ b/yamal-bovanenkovo-sim/construction.js
@@ -1,0 +1,236 @@
+window.YamalSim = window.YamalSim || {};
+
+window.YamalSim.construction = (() => {
+  function vehicleBulldozer() {
+    const g = new THREE.Group();
+    const body = new THREE.Mesh(
+      new THREE.BoxGeometry(6.2, 2.2, 4),
+      new THREE.MeshStandardMaterial({ color: 0xc9a137, roughness: 0.75 })
+    );
+    body.position.y = 2;
+    g.add(body);
+
+    const cabin = new THREE.Mesh(
+      new THREE.BoxGeometry(2.4, 1.6, 2.3),
+      new THREE.MeshStandardMaterial({ color: 0x4f5d66, roughness: 0.6 })
+    );
+    cabin.position.set(0.8, 3, 0);
+    g.add(cabin);
+
+    const blade = new THREE.Mesh(
+      new THREE.BoxGeometry(6.4, 1.4, 0.4),
+      new THREE.MeshStandardMaterial({ color: 0x69737a, roughness: 0.8 })
+    );
+    blade.position.set(0, 1.2, 2.3);
+    g.add(blade);
+
+    const trackGeo = new THREE.BoxGeometry(6.6, 0.8, 0.9);
+    const trackMat = new THREE.MeshStandardMaterial({ color: 0x2e3439, roughness: 0.95 });
+    const t1 = new THREE.Mesh(trackGeo, trackMat);
+    t1.position.set(0, 0.6, 1.6);
+    const t2 = t1.clone();
+    t2.position.z = -1.6;
+    g.add(t1, t2);
+    return g;
+  }
+
+  function vehicleDumpTruck() {
+    const g = new THREE.Group();
+    const base = new THREE.Mesh(new THREE.BoxGeometry(8, 1.5, 3.5), new THREE.MeshStandardMaterial({ color: 0x4b565f }));
+    base.position.y = 1.5;
+    g.add(base);
+
+    const cab = new THREE.Mesh(new THREE.BoxGeometry(2.4, 2.1, 3.3), new THREE.MeshStandardMaterial({ color: 0xc68f3a }));
+    cab.position.set(-2.4, 2.7, 0);
+    g.add(cab);
+
+    const bed = new THREE.Mesh(new THREE.BoxGeometry(4.6, 1.9, 3.1), new THREE.MeshStandardMaterial({ color: 0x7d878f }));
+    bed.position.set(1.6, 2.8, 0);
+    g.add(bed);
+
+    const wheelGeo = new THREE.CylinderGeometry(0.72, 0.72, 0.55, 12);
+    const wheelMat = new THREE.MeshStandardMaterial({ color: 0x1f2327 });
+    for (let x = -2.6; x <= 2.6; x += 2.6) {
+      for (let z = -1.7; z <= 1.7; z += 3.4) {
+        const w = new THREE.Mesh(wheelGeo, wheelMat);
+        w.rotation.z = Math.PI / 2;
+        w.position.set(x, 0.75, z);
+        g.add(w);
+      }
+    }
+    return g;
+  }
+
+  function vehicleCrawlerCrane() {
+    const g = new THREE.Group();
+    const base = new THREE.Mesh(new THREE.BoxGeometry(7.2, 2, 4.2), new THREE.MeshStandardMaterial({ color: 0xb68234 }));
+    base.position.y = 2;
+    g.add(base);
+
+    const cabin = new THREE.Mesh(new THREE.BoxGeometry(2.4, 2.4, 2.2), new THREE.MeshStandardMaterial({ color: 0x5a6874 }));
+    cabin.position.set(-1.5, 4, 0);
+    g.add(cabin);
+
+    const boom = new THREE.Mesh(new THREE.BoxGeometry(0.45, 0.45, 18), new THREE.MeshStandardMaterial({ color: 0x7a858f }));
+    boom.position.set(2, 6.4, -5);
+    boom.rotation.x = Math.PI * 0.18;
+    g.add(boom);
+
+    const track = new THREE.Mesh(new THREE.BoxGeometry(7.6, 0.8, 1), new THREE.MeshStandardMaterial({ color: 0x2c3338 }));
+    track.position.set(0, 0.6, 1.8);
+    const track2 = track.clone();
+    track2.position.z = -1.8;
+    g.add(track, track2);
+    return g;
+  }
+
+  function vehiclePipeLayer() {
+    const g = vehicleBulldozer();
+    const arm = new THREE.Mesh(new THREE.BoxGeometry(0.4, 4.8, 0.4), new THREE.MeshStandardMaterial({ color: 0x7f8b96 }));
+    arm.position.set(1.6, 4.4, -1.8);
+    g.add(arm);
+    const hook = new THREE.Mesh(new THREE.TorusGeometry(0.5, 0.1, 8, 16), new THREE.MeshStandardMaterial({ color: 0x2f363d }));
+    hook.position.set(1.6, 2.4, -1.8);
+    g.add(hook);
+    return g;
+  }
+
+  function vehicleATV() {
+    const g = new THREE.Group();
+    const body = new THREE.Mesh(new THREE.BoxGeometry(3.6, 1.2, 2), new THREE.MeshStandardMaterial({ color: 0x67755a }));
+    body.position.y = 1.5;
+    g.add(body);
+
+    const top = new THREE.Mesh(new THREE.BoxGeometry(2, 0.9, 1.7), new THREE.MeshStandardMaterial({ color: 0x4d5b4f }));
+    top.position.set(0, 2.2, 0);
+    g.add(top);
+
+    const wheelGeo = new THREE.CylinderGeometry(0.46, 0.46, 0.36, 10);
+    const wheelMat = new THREE.MeshStandardMaterial({ color: 0x23272c });
+    for (let x = -1.3; x <= 1.3; x += 2.6) {
+      for (let z = -1.1; z <= 1.1; z += 2.2) {
+        const w = new THREE.Mesh(wheelGeo, wheelMat);
+        w.rotation.z = Math.PI / 2;
+        w.position.set(x, 0.7, z);
+        g.add(w);
+      }
+    }
+
+    return g;
+  }
+
+  function makePipeStack(length = 18, count = 5, spacing = 1.35) {
+    const g = new THREE.Group();
+    const mat = new THREE.MeshStandardMaterial({ color: 0x5f6972, roughness: 0.8, metalness: 0.2 });
+    const pipeGeo = new THREE.CylinderGeometry(0.55, 0.55, length, 16);
+
+    for (let row = 0; row < 3; row++) {
+      for (let i = 0; i < count; i++) {
+        const p = new THREE.Mesh(pipeGeo, mat);
+        p.rotation.z = Math.PI / 2;
+        p.position.set((i - count * 0.5) * spacing, 0.55 + row * 1.05, row % 2 ? 0.62 : 0);
+        p.castShadow = true;
+        p.receiveShadow = true;
+        g.add(p);
+      }
+    }
+
+    return g;
+  }
+
+  function floodlightPole() {
+    const g = new THREE.Group();
+    const pole = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.22, 0.3, 13, 8),
+      new THREE.MeshStandardMaterial({ color: 0x596672 })
+    );
+    pole.position.y = 6.5;
+    g.add(pole);
+
+    const bar = new THREE.Mesh(new THREE.BoxGeometry(2.8, 0.2, 0.2), new THREE.MeshStandardMaterial({ color: 0x6c7884 }));
+    bar.position.set(0, 12.3, 0);
+    g.add(bar);
+
+    const lamp = new THREE.Mesh(new THREE.BoxGeometry(0.6, 0.35, 0.4), new THREE.MeshStandardMaterial({ color: 0xa2b2c1, emissive: 0xf8edcc, emissiveIntensity: 0.2 }));
+    lamp.position.set(0.8, 12.1, 0);
+    const lamp2 = lamp.clone();
+    lamp2.position.x = -0.8;
+    g.add(lamp, lamp2);
+
+    return g;
+  }
+
+  function createConstructionZones(terrain, scene) {
+    const group = new THREE.Group();
+    group.name = "ConstructionZones";
+
+    const placement = [
+      [vehicleBulldozer(), 70, -80, 0.4],
+      [vehicleDumpTruck(), 110, -130, -0.2],
+      [vehicleCrawlerCrane(), 140, -40, 0.9],
+      [vehiclePipeLayer(), 210, -190, 1.7],
+      [vehicleDumpTruck(), 260, -150, 0.5],
+      [vehicleATV(), -40, -70, 0.2],
+      [vehicleATV(), -300, 140, -1.2],
+    ];
+
+    placement.forEach(([mesh, x, z, ry]) => {
+      mesh.position.set(x, terrain.getHeightAt(x, z), z);
+      mesh.rotation.y = ry;
+      mesh.traverse((o) => {
+        if (o.isMesh) {
+          o.castShadow = true;
+          o.receiveShadow = true;
+        }
+      });
+      group.add(mesh);
+    });
+
+    for (let i = 0; i < 9; i++) {
+      const stack = makePipeStack(20, 6, 1.4);
+      const x = 180 + (i % 3) * 34;
+      const z = 40 + Math.floor(i / 3) * 26;
+      stack.position.set(x, terrain.getHeightAt(x, z), z);
+      stack.rotation.y = i % 2 ? Math.PI / 2 : 0;
+      group.add(stack);
+    }
+
+    for (let i = 0; i < 12; i++) {
+      const cont = new THREE.Mesh(
+        new THREE.BoxGeometry(7, 2.9, 2.9),
+        new THREE.MeshStandardMaterial({ color: i % 3 === 0 ? 0x6f808f : 0x7e8e9a, roughness: 0.88 })
+      );
+      const x = 40 + (i % 6) * 9;
+      const z = -220 + Math.floor(i / 6) * 4;
+      cont.position.set(x, terrain.getHeightAt(x, z) + 1.45, z);
+      cont.castShadow = true;
+      cont.receiveShadow = true;
+      group.add(cont);
+    }
+
+    const mastPositions = [
+      [0, -130], [130, -90], [230, -40], [230, 80], [90, 140], [-80, 30], [-250, 150],
+    ];
+
+    const lights = [];
+    mastPositions.forEach((p) => {
+      const pole = floodlightPole();
+      pole.position.set(p[0], terrain.getHeightAt(p[0], p[1]), p[1]);
+      group.add(pole);
+
+      const light = new THREE.SpotLight(0xdde8f8, 0.7, 120, Math.PI / 5, 0.5, 1.2);
+      light.position.set(p[0], pole.position.y + 12.2, p[1]);
+      light.target.position.set(p[0], terrain.getHeightAt(p[0], p[1]), p[1]);
+      light.castShadow = false;
+      scene.add(light.target);
+      scene.add(light);
+      lights.push(light);
+    });
+
+    return { group, lights };
+  }
+
+  return {
+    createConstructionZones,
+  };
+})();

--- a/yamal-bovanenkovo-sim/controls.js
+++ b/yamal-bovanenkovo-sim/controls.js
@@ -1,0 +1,88 @@
+window.YamalSim = window.YamalSim || {};
+
+window.YamalSim.controls = (() => {
+  const { clamp } = window.YamalSim.utils;
+
+  function setupControls(camera, domElement, terrain) {
+    const controls = new THREE.PointerLockControls(camera, domElement);
+    const state = {
+      controls,
+      velocity: new THREE.Vector3(),
+      direction: new THREE.Vector3(),
+      keys: {
+        KeyW: false,
+        KeyA: false,
+        KeyS: false,
+        KeyD: false,
+        ShiftLeft: false,
+        Space: false,
+      },
+      canJump: false,
+      eyeHeight: 1.7,
+    };
+
+    const onKey = (ev, down) => {
+      if (state.keys.hasOwnProperty(ev.code)) state.keys[ev.code] = down;
+      if (ev.code === "Space") ev.preventDefault();
+    };
+
+    window.addEventListener("keydown", (ev) => onKey(ev, true));
+    window.addEventListener("keyup", (ev) => onKey(ev, false));
+
+    controls.addEventListener("lock", () => {
+      state.isLocked = true;
+    });
+
+    controls.addEventListener("unlock", () => {
+      state.isLocked = false;
+    });
+
+    function update(delta) {
+      if (!state.isLocked) return;
+
+      const speed = state.keys.ShiftLeft ? 45 : 26;
+      const damping = 10;
+
+      state.velocity.x -= state.velocity.x * damping * delta;
+      state.velocity.z -= state.velocity.z * damping * delta;
+      state.velocity.y -= 30 * delta;
+
+      state.direction.z = Number(state.keys.KeyW) - Number(state.keys.KeyS);
+      state.direction.x = Number(state.keys.KeyD) - Number(state.keys.KeyA);
+      state.direction.normalize();
+
+      if (state.direction.z !== 0) state.velocity.z -= state.direction.z * speed * delta;
+      if (state.direction.x !== 0) state.velocity.x -= state.direction.x * speed * delta;
+
+      if (state.keys.Space && state.canJump) {
+        state.velocity.y = 10.5;
+        state.canJump = false;
+      }
+
+      controls.moveRight(-state.velocity.x * delta);
+      controls.moveForward(-state.velocity.z * delta);
+      controls.getObject().position.y += state.velocity.y * delta;
+
+      const p = controls.getObject().position;
+      const terrainY = terrain.getHeightAt(p.x, p.z) + state.eyeHeight;
+
+      if (p.y < terrainY) {
+        state.velocity.y = 0;
+        p.y = terrainY;
+        state.canJump = true;
+      }
+
+      p.y = clamp(p.y, terrainY, terrainY + 14);
+    }
+
+    return {
+      controls,
+      state,
+      update,
+    };
+  }
+
+  return {
+    setupControls,
+  };
+})();

--- a/yamal-bovanenkovo-sim/environment.js
+++ b/yamal-bovanenkovo-sim/environment.js
@@ -1,0 +1,110 @@
+window.YamalSim = window.YamalSim || {};
+
+window.YamalSim.environment = (() => {
+  function createSkyDome() {
+    const geo = new THREE.SphereGeometry(1900, 32, 16);
+    const mat = new THREE.ShaderMaterial({
+      side: THREE.BackSide,
+      uniforms: {
+        topColor: { value: new THREE.Color(0x889eb5) },
+        bottomColor: { value: new THREE.Color(0xd3dce8) },
+        offset: { value: 120 },
+        exponent: { value: 0.7 },
+      },
+      vertexShader: `
+        varying vec3 vWorldPosition;
+        void main() {
+          vec4 worldPosition = modelMatrix * vec4(position, 1.0);
+          vWorldPosition = worldPosition.xyz;
+          gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        }
+      `,
+      fragmentShader: `
+        uniform vec3 topColor;
+        uniform vec3 bottomColor;
+        uniform float offset;
+        uniform float exponent;
+        varying vec3 vWorldPosition;
+        void main() {
+          float h = normalize(vWorldPosition + offset).y;
+          float t = max(pow(max(h, 0.0), exponent), 0.0);
+          gl_FragColor = vec4(mix(bottomColor, topColor, t), 1.0);
+        }
+      `,
+    });
+
+    return new THREE.Mesh(geo, mat);
+  }
+
+  function setupEnvironment(scene) {
+    scene.fog = new THREE.Fog(0xb7c4d2, 130, 1150);
+
+    const ambient = new THREE.HemisphereLight(0xdbe7f4, 0x6f7780, 0.72);
+    scene.add(ambient);
+
+    const sun = new THREE.DirectionalLight(0xdfe8f5, 0.82);
+    sun.position.set(180, 250, 120);
+    sun.castShadow = true;
+    sun.shadow.mapSize.set(2048, 2048);
+    sun.shadow.camera.left = -380;
+    sun.shadow.camera.right = 380;
+    sun.shadow.camera.top = 380;
+    sun.shadow.camera.bottom = -380;
+    sun.shadow.camera.near = 1;
+    sun.shadow.camera.far = 900;
+    scene.add(sun);
+
+    const sky = createSkyDome();
+    scene.add(sky);
+
+    return {
+      ambient,
+      sun,
+      sky,
+      timeMode: "day",
+      timer: 0,
+    };
+  }
+
+  function setMode(state, scene, mode) {
+    state.timeMode = mode;
+    if (mode === "day") {
+      state.sun.intensity = 0.84;
+      state.sun.color.set(0xdfebf8);
+      state.ambient.intensity = 0.72;
+      scene.fog.color.set(0xb7c4d2);
+      scene.fog.near = 140;
+      scene.fog.far = 1180;
+      state.sky.material.uniforms.topColor.value.set(0x869bb1);
+      state.sky.material.uniforms.bottomColor.value.set(0xd4deea);
+    } else {
+      state.sun.intensity = 0.45;
+      state.sun.color.set(0xb7c9e0);
+      state.ambient.intensity = 0.5;
+      scene.fog.color.set(0x94a4b8);
+      scene.fog.near = 110;
+      scene.fog.far = 920;
+      state.sky.material.uniforms.topColor.value.set(0x617992);
+      state.sky.material.uniforms.bottomColor.value.set(0xaebbcf);
+    }
+  }
+
+  function updateEnvironment(state, scene, delta, autoCycle = true) {
+    state.timer += delta;
+    if (autoCycle && state.timer > 65) {
+      const next = state.timeMode === "day" ? "dusk" : "day";
+      setMode(state, scene, next);
+      state.timer = 0;
+    }
+
+    const t = performance.now() * 0.00007;
+    state.sun.position.x = Math.cos(t) * 240;
+    state.sun.position.z = Math.sin(t) * 180;
+  }
+
+  return {
+    setupEnvironment,
+    updateEnvironment,
+    setMode,
+  };
+})();

--- a/yamal-bovanenkovo-sim/index.html
+++ b/yamal-bovanenkovo-sim/index.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Yamal Bovanenkovo Construction Simulator</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <div id="startOverlay" class="overlay visible">
+    <div class="overlay-card">
+      <h1>Yamal Bovanenkovo Construction Simulator</h1>
+      <p>
+        Атмосферный симулятор пешего обхода северной стройки в условиях арктической тундры.
+        Изучайте модульный городок, строительные зоны, склад труб и удалённую тундру.
+      </p>
+      <ul>
+        <li><b>WASD</b> — движение</li>
+        <li><b>Mouse</b> — обзор</li>
+        <li><b>Shift</b> — ускорение</li>
+        <li><b>Space</b> — лёгкий прыжок</li>
+      </ul>
+      <button id="startBtn">Начать</button>
+      <small>После старта курсор будет захвачен (Pointer Lock).</small>
+    </div>
+  </div>
+
+  <div id="hud" class="hud">
+    <div class="hud-title">Yamal Bovanenkovo Construction Simulator</div>
+    <div class="hud-row">WASD — движение | Shift — бег | Space — прыжок | Mouse — обзор | T — смена времени</div>
+    <div class="hud-row" id="coords">X: 0 | Y: 1.7 | Z: 0</div>
+    <div class="hud-row" id="zone">Zone: STROYPLOSHCHADKA</div>
+    <div class="hud-row" id="weather">Weather: Light Snow</div>
+  </div>
+
+  <div id="crosshair">+</div>
+
+  <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.152.2/examples/js/controls/PointerLockControls.js"></script>
+
+  <script src="./utils.js"></script>
+  <script src="./terrain.js"></script>
+  <script src="./environment.js"></script>
+  <script src="./roads.js"></script>
+  <script src="./buildings.js"></script>
+  <script src="./construction.js"></script>
+  <script src="./animals.js"></script>
+  <script src="./weather.js"></script>
+  <script src="./controls.js"></script>
+  <script src="./ui.js"></script>
+  <script src="./scene.js"></script>
+  <script src="./main.js"></script>
+</body>
+</html>

--- a/yamal-bovanenkovo-sim/main.js
+++ b/yamal-bovanenkovo-sim/main.js
@@ -1,0 +1,5 @@
+window.addEventListener("DOMContentLoaded", () => {
+  const game = window.YamalSim.scene.createScene();
+  game.ui = window.YamalSim.ui.setupUI(game);
+  window.YamalSim.scene.animate(game);
+});

--- a/yamal-bovanenkovo-sim/roads.js
+++ b/yamal-bovanenkovo-sim/roads.js
@@ -1,0 +1,53 @@
+window.YamalSim = window.YamalSim || {};
+
+window.YamalSim.roads = (() => {
+  function roadSegment(length, width, color = 0x8f9498) {
+    const mesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(width, length),
+      new THREE.MeshStandardMaterial({ color, roughness: 1, metalness: 0 })
+    );
+    mesh.rotation.x = -Math.PI / 2;
+    mesh.receiveShadow = true;
+    return mesh;
+  }
+
+  function createRoadNetwork(terrain) {
+    const group = new THREE.Group();
+    group.name = "RoadNetwork";
+
+    const main = roadSegment(1050, 26, 0x8a8f93);
+    main.position.set(40, terrain.getHeightAt(40, 0) + 0.25, 0);
+    group.add(main);
+
+    const branch1 = roadSegment(460, 16, 0x858b8f);
+    branch1.position.set(-120, terrain.getHeightAt(-120, -190) + 0.2, -190);
+    branch1.rotation.y = Math.PI / 2.8;
+    group.add(branch1);
+
+    const branch2 = roadSegment(620, 18, 0x83888c);
+    branch2.position.set(190, terrain.getHeightAt(190, 160) + 0.2, 160);
+    branch2.rotation.y = -Math.PI / 3.2;
+    group.add(branch2);
+
+    const campRoad = roadSegment(320, 14, 0x8f9499);
+    campRoad.position.set(-260, terrain.getHeightAt(-260, 120) + 0.18, 120);
+    campRoad.rotation.y = -Math.PI / 2;
+    group.add(campRoad);
+
+    for (let i = 0; i < 18; i++) {
+      const mark = new THREE.Mesh(
+        new THREE.PlaneGeometry(1.2, 7),
+        new THREE.MeshBasicMaterial({ color: 0xc8ced3, transparent: true, opacity: 0.42 })
+      );
+      mark.rotation.x = -Math.PI / 2;
+      mark.position.set(40, terrain.getHeightAt(40, -500 + i * 56) + 0.29, -500 + i * 56);
+      group.add(mark);
+    }
+
+    return group;
+  }
+
+  return {
+    createRoadNetwork,
+  };
+})();

--- a/yamal-bovanenkovo-sim/scene.js
+++ b/yamal-bovanenkovo-sim/scene.js
@@ -1,0 +1,110 @@
+window.YamalSim = window.YamalSim || {};
+
+window.YamalSim.scene = (() => {
+  function buildRenderer() {
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.shadowMap.enabled = true;
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    document.body.appendChild(renderer.domElement);
+    return renderer;
+  }
+
+  function createScene() {
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 2500);
+    camera.position.set(-240, 8, 80);
+
+    const renderer = buildRenderer();
+    const terrain = window.YamalSim.terrain;
+
+    const terrainMesh = terrain.createTerrain();
+    scene.add(terrainMesh);
+
+    const env = window.YamalSim.environment.setupEnvironment(scene);
+
+    const roads = window.YamalSim.roads.createRoadNetwork(terrain);
+    scene.add(roads);
+
+    const camp = window.YamalSim.buildings.createCamp(terrain);
+    scene.add(camp);
+
+    const constr = window.YamalSim.construction.createConstructionZones(terrain, scene);
+    scene.add(constr.group);
+
+    const animals = window.YamalSim.animals.createAnimals(terrain);
+    scene.add(animals.group);
+
+    const weather = window.YamalSim.weather.createSnowSystem(2600);
+    scene.add(weather.points);
+
+    const controls = window.YamalSim.controls.setupControls(camera, renderer.domElement, terrain);
+    scene.add(controls.controls.getObject());
+
+    controls.controls.getObject().position.set(-240, terrain.getHeightAt(-240, 80) + 1.7, 80);
+
+    const game = {
+      scene,
+      camera,
+      renderer,
+      terrain,
+      environment: env,
+      controls,
+      weather,
+      animals,
+      floodlights: constr.lights,
+      ui: null,
+      lastTime: performance.now(),
+      autoCycle: true,
+    };
+
+    window.addEventListener("resize", () => {
+      game.camera.aspect = window.innerWidth / window.innerHeight;
+      game.camera.updateProjectionMatrix();
+      game.renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+
+    window.addEventListener("keydown", (ev) => {
+      if (ev.code === "KeyT") {
+        const next = game.environment.timeMode === "day" ? "dusk" : "day";
+        window.YamalSim.environment.setMode(game.environment, game.scene, next);
+      }
+    });
+
+    return game;
+  }
+
+  function updateFloodlights(game, delta) {
+    const evening = game.environment.timeMode === "dusk";
+    game.floodlights.forEach((l) => {
+      const targetIntensity = evening ? 1.15 : 0.55;
+      l.intensity += (targetIntensity - l.intensity) * Math.min(delta * 2.5, 1);
+      l.distance = evening ? 150 : 100;
+    });
+  }
+
+  function animate(game) {
+    const now = performance.now();
+    const delta = Math.min((now - game.lastTime) / 1000, 0.05);
+    game.lastTime = now;
+
+    game.controls.update(delta);
+    window.YamalSim.environment.updateEnvironment(game.environment, game.scene, delta, game.autoCycle);
+    window.YamalSim.weather.updateWeather(game.weather, game.scene, game.controls.controls.getObject().position, delta * 60);
+    window.YamalSim.animals.updateAnimals(game.animals, game.terrain, delta * 60);
+    updateFloodlights(game, delta);
+
+    if (game.ui) {
+      game.ui.update(game.controls.controls.getObject().position, game.weather.mode);
+    }
+
+    game.renderer.render(game.scene, game.camera);
+    requestAnimationFrame(() => animate(game));
+  }
+
+  return {
+    createScene,
+    animate,
+  };
+})();

--- a/yamal-bovanenkovo-sim/style.css
+++ b/yamal-bovanenkovo-sim/style.css
@@ -1,0 +1,118 @@
+:root {
+  --hud-bg: rgba(12, 18, 26, 0.65);
+  --hud-border: rgba(155, 178, 196, 0.4);
+  --text: #dbe7f2;
+  --accent: #d5af56;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  font-family: "Segoe UI", Tahoma, sans-serif;
+  background: #8ea2b6;
+  color: var(--text);
+}
+
+canvas {
+  display: block;
+}
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at center, rgba(14, 22, 30, 0.82), rgba(5, 9, 14, 0.94));
+  z-index: 20;
+}
+
+.overlay.visible {
+  display: flex;
+}
+
+.overlay-card {
+  width: min(760px, 92vw);
+  background: rgba(12, 18, 26, 0.92);
+  border: 1px solid var(--hud-border);
+  border-radius: 14px;
+  padding: 22px 24px;
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.35);
+}
+
+.overlay-card h1 {
+  margin: 0 0 12px;
+  font-size: clamp(22px, 3vw, 34px);
+  color: #f0f5fb;
+}
+
+.overlay-card p,
+.overlay-card li,
+.overlay-card small {
+  color: #c8d6e4;
+}
+
+.overlay-card ul {
+  margin: 12px 0 16px;
+  padding-left: 18px;
+}
+
+#startBtn {
+  margin-top: 8px;
+  padding: 11px 18px;
+  border-radius: 10px;
+  border: 1px solid #8c9dae;
+  background: linear-gradient(180deg, #f2f6fb, #cbd9e8);
+  color: #152130;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+#startBtn:hover {
+  filter: brightness(0.95);
+}
+
+.hud {
+  position: fixed;
+  top: 14px;
+  left: 14px;
+  z-index: 12;
+  min-width: min(520px, 92vw);
+  background: var(--hud-bg);
+  border: 1px solid var(--hud-border);
+  border-radius: 12px;
+  padding: 10px 12px;
+  backdrop-filter: blur(4px);
+}
+
+.hud-title {
+  color: #f0f6fd;
+  font-weight: 700;
+  font-size: 14px;
+  margin-bottom: 6px;
+}
+
+.hud-row {
+  color: #d0deec;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+#crosshair {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 11;
+  color: rgba(236, 241, 247, 0.75);
+  font-size: 19px;
+  user-select: none;
+  pointer-events: none;
+}

--- a/yamal-bovanenkovo-sim/terrain.js
+++ b/yamal-bovanenkovo-sim/terrain.js
@@ -1,0 +1,68 @@
+window.YamalSim = window.YamalSim || {};
+
+window.YamalSim.terrain = (() => {
+  const { fbmNoise, clamp } = window.YamalSim.utils;
+
+  const TERRAIN_SIZE = 2200;
+  const TERRAIN_SEGMENTS = 260;
+
+  function getHeightAt(x, z) {
+    const base = (fbmNoise(x * 0.0022, z * 0.0022, 5) - 0.5) * 10.0;
+    const details = (fbmNoise((x + 300) * 0.007, (z - 190) * 0.007, 3) - 0.5) * 1.9;
+    const hills = (fbmNoise((x - 700) * 0.0012, (z + 120) * 0.0012, 4) - 0.5) * 20;
+
+    const flattenSite = Math.exp(-((x * x + z * z) / (900 * 900)));
+    const siteOffset = flattenSite * -2.2;
+
+    return clamp(base + details + hills + siteOffset, -9, 18);
+  }
+
+  function createTerrain() {
+    const geometry = new THREE.PlaneGeometry(TERRAIN_SIZE, TERRAIN_SIZE, TERRAIN_SEGMENTS, TERRAIN_SEGMENTS);
+    geometry.rotateX(-Math.PI / 2);
+
+    const pos = geometry.attributes.position;
+    const colors = [];
+    const color = new THREE.Color();
+
+    for (let i = 0; i < pos.count; i++) {
+      const x = pos.getX(i);
+      const z = pos.getZ(i);
+      const h = getHeightAt(x, z);
+      pos.setY(i, h);
+
+      const n = (h + 10) / 28;
+      color.setRGB(
+        0.84 - n * 0.09,
+        0.88 - n * 0.07,
+        0.93 - n * 0.1
+      );
+
+      if (Math.abs(x) < 360 && Math.abs(z) < 260) {
+        color.lerp(new THREE.Color(0.75, 0.77, 0.79), 0.34);
+      }
+
+      colors.push(color.r, color.g, color.b);
+    }
+
+    geometry.setAttribute("color", new THREE.Float32BufferAttribute(colors, 3));
+    geometry.computeVertexNormals();
+
+    const material = new THREE.MeshStandardMaterial({
+      vertexColors: true,
+      roughness: 0.93,
+      metalness: 0.02,
+    });
+
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.receiveShadow = true;
+
+    return mesh;
+  }
+
+  return {
+    createTerrain,
+    getHeightAt,
+    TERRAIN_SIZE,
+  };
+})();

--- a/yamal-bovanenkovo-sim/ui.js
+++ b/yamal-bovanenkovo-sim/ui.js
@@ -1,0 +1,43 @@
+window.YamalSim = window.YamalSim || {};
+
+window.YamalSim.ui = (() => {
+  function determineZone(x, z) {
+    if (x < -120 && z > 60 && z < 250) return "МОДУЛЬНЫЙ ГОРОДОК";
+    if (x > 120 && z > -20 && z < 190) return "СКЛАД ТРУБ";
+    if (Math.abs(x) < 350 && Math.abs(z) < 300) return "СТРОЙПЛОЩАДКА";
+    if (Math.hypot(x, z) > 640) return "ТУНДРА";
+    return "ПРОМЗОНА";
+  }
+
+  function setupUI(game) {
+    const overlay = document.getElementById("startOverlay");
+    const startBtn = document.getElementById("startBtn");
+    const coords = document.getElementById("coords");
+    const zone = document.getElementById("zone");
+    const weather = document.getElementById("weather");
+
+    startBtn.addEventListener("click", () => {
+      overlay.classList.remove("visible");
+      game.controls.controls.lock();
+    });
+
+    game.controls.controls.addEventListener("unlock", () => {
+      overlay.classList.add("visible");
+    });
+
+    function update(playerPos, weatherMode) {
+      coords.textContent = `X: ${playerPos.x.toFixed(1)} | Y: ${playerPos.y.toFixed(1)} | Z: ${playerPos.z.toFixed(1)}`;
+      zone.textContent = `Zone: ${determineZone(playerPos.x, playerPos.z)}`;
+      weather.textContent = `Weather: ${weatherMode}`;
+    }
+
+    return {
+      update,
+    };
+  }
+
+  return {
+    setupUI,
+    determineZone,
+  };
+})();

--- a/yamal-bovanenkovo-sim/utils.js
+++ b/yamal-bovanenkovo-sim/utils.js
@@ -1,0 +1,83 @@
+window.YamalSim = window.YamalSim || {};
+
+window.YamalSim.utils = (() => {
+  const tmpVec3 = new THREE.Vector3();
+
+  function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+  }
+
+  function lerp(a, b, t) {
+    return a + (b - a) * t;
+  }
+
+  function rand(min, max) {
+    return min + Math.random() * (max - min);
+  }
+
+  function randInt(min, max) {
+    return Math.floor(rand(min, max + 1));
+  }
+
+  function hash2D(x, z) {
+    const s = Math.sin(x * 127.1 + z * 311.7) * 43758.5453123;
+    return s - Math.floor(s);
+  }
+
+  function smoothNoise2D(x, z) {
+    const x0 = Math.floor(x);
+    const z0 = Math.floor(z);
+    const tx = x - x0;
+    const tz = z - z0;
+
+    const n00 = hash2D(x0, z0);
+    const n10 = hash2D(x0 + 1, z0);
+    const n01 = hash2D(x0, z0 + 1);
+    const n11 = hash2D(x0 + 1, z0 + 1);
+
+    const sx = tx * tx * (3 - 2 * tx);
+    const sz = tz * tz * (3 - 2 * tz);
+
+    const nx0 = n00 * (1 - sx) + n10 * sx;
+    const nx1 = n01 * (1 - sx) + n11 * sx;
+    return nx0 * (1 - sz) + nx1 * sz;
+  }
+
+  function fbmNoise(x, z, octaves = 4) {
+    let amplitude = 1;
+    let frequency = 1;
+    let sum = 0;
+    let norm = 0;
+
+    for (let i = 0; i < octaves; i++) {
+      sum += smoothNoise2D(x * frequency, z * frequency) * amplitude;
+      norm += amplitude;
+      amplitude *= 0.5;
+      frequency *= 2;
+    }
+
+    return sum / norm;
+  }
+
+  function distance2D(ax, az, bx, bz) {
+    const dx = ax - bx;
+    const dz = az - bz;
+    return Math.hypot(dx, dz);
+  }
+
+  function lookAtYaw(from, to) {
+    tmpVec3.copy(to).sub(from);
+    return Math.atan2(tmpVec3.x, tmpVec3.z);
+  }
+
+  return {
+    clamp,
+    lerp,
+    rand,
+    randInt,
+    smoothNoise2D,
+    fbmNoise,
+    distance2D,
+    lookAtYaw,
+  };
+})();

--- a/yamal-bovanenkovo-sim/weather.js
+++ b/yamal-bovanenkovo-sim/weather.js
@@ -1,0 +1,96 @@
+window.YamalSim = window.YamalSim || {};
+
+window.YamalSim.weather = (() => {
+  const { rand, lerp } = window.YamalSim.utils;
+
+  function createSnowSystem(count = 2400) {
+    const geometry = new THREE.BufferGeometry();
+    const positions = new Float32Array(count * 3);
+    const speeds = new Float32Array(count);
+
+    for (let i = 0; i < count; i++) {
+      positions[i * 3] = rand(-750, 750);
+      positions[i * 3 + 1] = rand(3, 130);
+      positions[i * 3 + 2] = rand(-750, 750);
+      speeds[i] = rand(0.8, 2.4);
+    }
+
+    geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+
+    const material = new THREE.PointsMaterial({
+      color: 0xe9f2fd,
+      size: 0.7,
+      transparent: true,
+      opacity: 0.68,
+      depthWrite: false,
+    });
+
+    const points = new THREE.Points(geometry, material);
+    points.frustumCulled = false;
+
+    return {
+      points,
+      speeds,
+      intensity: 0.3,
+      stateTimer: 0,
+      mode: "Light Snow",
+      wind: new THREE.Vector2(0.6, 0.2),
+    };
+  }
+
+  function updateWeather(weather, scene, playerPosition, delta) {
+    weather.stateTimer += delta;
+    const p = weather.points.geometry.attributes.position.array;
+
+    if (weather.stateTimer > 22) {
+      weather.stateTimer = 0;
+      const r = Math.random();
+      if (r < 0.45) {
+        weather.mode = "Light Snow";
+        weather.intensity = 0.28;
+      } else if (r < 0.85) {
+        weather.mode = "Normal Visibility";
+        weather.intensity = 0.18;
+      } else {
+        weather.mode = "Snow Mist";
+        weather.intensity = 0.5;
+      }
+    }
+
+    weather.wind.x = lerp(weather.wind.x, Math.sin(performance.now() * 0.00019) * 1.7, delta * 0.2);
+    weather.wind.y = lerp(weather.wind.y, Math.cos(performance.now() * 0.00015) * 1.2, delta * 0.2);
+
+    for (let i = 0; i < weather.speeds.length; i++) {
+      const idx = i * 3;
+      p[idx] += weather.wind.x * 0.03 * weather.speeds[i] * delta;
+      p[idx + 2] += weather.wind.y * 0.03 * weather.speeds[i] * delta;
+      p[idx + 1] -= weather.speeds[i] * weather.intensity * delta;
+
+      const localX = p[idx] - playerPosition.x;
+      const localZ = p[idx + 2] - playerPosition.z;
+      if (p[idx + 1] < 0 || Math.abs(localX) > 900 || Math.abs(localZ) > 900) {
+        p[idx] = playerPosition.x + rand(-700, 700);
+        p[idx + 1] = rand(40, 130);
+        p[idx + 2] = playerPosition.z + rand(-700, 700);
+      }
+    }
+
+    weather.points.geometry.attributes.position.needsUpdate = true;
+
+    if (weather.mode === "Snow Mist") {
+      scene.fog.near = lerp(scene.fog.near, 90, delta * 0.6);
+      scene.fog.far = lerp(scene.fog.far, 740, delta * 0.6);
+    } else if (weather.mode === "Normal Visibility") {
+      scene.fog.near = lerp(scene.fog.near, 170, delta * 0.6);
+      scene.fog.far = lerp(scene.fog.far, 1260, delta * 0.6);
+    } else {
+      scene.fog.near = lerp(scene.fog.near, 130, delta * 0.6);
+      scene.fog.far = lerp(scene.fog.far, 1040, delta * 0.6);
+    }
+  }
+
+  return {
+    createSnowSystem,
+    updateWeather,
+  };
+})();


### PR DESCRIPTION
### Motivation
- Provide a complete, no-build browser-first Three.js first-person walking simulator that conveys an arctic industrial construction site (Yamal / Bovanenkovo) and can run by simply opening `index.html`. 
- Organize the project in small modules so scene, terrain, weather, animals, vehicles, UI and controls are easy to extend and maintain.

### Description
- Added a new self-contained project at `yamal-bovanenkovo-sim/` with the following files: `index.html`, `style.css`, `main.js`, `scene.js`, `terrain.js`, `environment.js`, `construction.js`, `buildings.js`, `roads.js`, `animals.js`, `weather.js`, `controls.js`, `ui.js`, `utils.js`, and `README.md` implementing the full simulator. 
- Implemented core systems: procedural arctic terrain (`terrain.js`) with FBM noise, sky/fog and day↔dusk mode (`environment.js`), snow particle system and wind (`weather.js`), sparse animal agents (foxes, very rare polar bears) with simple steering (`animals.js`), roads and camp layout (`roads.js`, `buildings.js`), construction vehicles/pipe stacks/floodlights (`construction.js`) and simplified asset composition from Three.js primitives. 
- First-person movement and basic physics are handled with `PointerLockControls` (`controls.js`) and an update loop in `scene.js`; HUD and start overlay are in `ui.js`; utilities (noise, random, helpers) are in `utils.js`. `index.html` loads Three.js and PointerLockControls from a CDN so no npm/build is required. 

### Testing
- Syntax/static checks: ran `for f in yamal-bovanenkovo-sim/*.js; do node --check "$f"; done` which completed successfully for all JS modules. 
- Served the folder with `python3 -m http.server` and attempted an automated screenshot via Playwright, but the headless Chromium crashed in this environment (SIGSEGV), so the automated rendering screenshot could not be obtained; the crash is environmental and not related to the shipped code. 
- Changes were committed to the repository and packaged as the new folder `yamal-bovanenkovo-sim/` ready for manual verification by opening `yamal-bovanenkovo-sim/index.html` in a modern browser.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab1f5e42fc832a977fb43fec369d3f)